### PR TITLE
開始日＞終了日でもエラーにならない

### DIFF
--- a/tableOutput.js
+++ b/tableOutput.js
@@ -162,9 +162,9 @@ function calcPeriod(start, end) {
     // console.log("endMonth = " + endMonth);
     let year = endYear - startYear;
     let month = endMonth - startMonth + 1;
-    if (month < 0) {
-        month += 12;
-    }
+    // if (month < 0) {
+    //     month += 12;
+    // }
     return month + year * 12;
 }
 


### PR DESCRIPTION
結合テストでの指摘
・作業期間・開始日より古い日付を終了日に設定した状態で「PDF出力」ボタン押下すると、「期間：その業務を行った期間を記入して下さい。」のアラートが表示されない